### PR TITLE
Fix ngist_supplementary_public repo url

### DIFF
--- a/docs/usage/installation.md
+++ b/docs/usage/installation.md
@@ -1,19 +1,19 @@
 # Installation[^1]
 [^1]: Installation has been tested using OSX and Linux. Windows OS is not currently supported.
 
-The pipeline is available via the [GECKOS Survey Github page](https://github.com/geckos-survey). There are two repositories here, the [nGIST](https://github.com/geckos-survey/nGIST) repo, which contains the nGIST code itself, and the [nGIST_supplementary_public](https://github.com/geckos-survey/ngist-supplementary-public) repo, which contains some extra examples to get you started.
+The pipeline is available via the [GECKOS Survey Github page](https://github.com/geckos-survey). There are two repositories here, the [nGIST](https://github.com/geckos-survey/nGIST) repo, which contains the nGIST code itself, and the [nGIST_supplementary_public](https://github.com/geckos-survey/ngist_supplementary_public) repo, which contains some extra examples to get you started.
 
 ### Cloning repositories 
-Clone the `ngist` and `ngist-supplementary-public` repos to your local machine using the SSH tab[^2]
+Clone the `ngist` and `ngist_supplementary_public` repos to your local machine using the SSH tab[^2]
 [^2]: If you haven't already, create an ssh key using ssh-keygen using the instructions [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/adding-a-new-ssh-key-to-your-github-account).
 
 `git clone git@github.com:geckos-survey/ngist.git`
 
-`git clone git@github.com:geckos-survey/ngist-supplementary-public.git`
+`git clone git@github.com:geckos-survey/ngist_supplementary_public.git`
 
 ### Setting up your python environment 
 (optional, but strongly recommended)
-Setup a separate python environment to run nGIST in. The `gistenv.yaml` file located in the `ngist-supplementary-public` repo can be used to install all of the dependencies and specified versions into a conda environment using the following call:
+Setup a separate python environment to run nGIST in. The `gistenv.yaml` file located in the `ngist_supplementary_public` repo can be used to install all of the dependencies and specified versions into a conda environment using the following call:
 
 ```py
 conda env create -f gistenv.yaml

--- a/docs/usage/usefulinfo.md
+++ b/docs/usage/usefulinfo.md
@@ -1,7 +1,7 @@
 # Useful information
 
 ### Folder setup
-The gistTutorial folder contained within the `nGIST-supplementary-public` repo is your working directory. Within it, you will find four folders: `configFiles`, `inputData`, `results`, and `spectralTemplates`. 
+The gistTutorial folder contained within the `nGIST_supplementary_public` repo is your working directory. Within it, you will find four folders: `configFiles`, `inputData`, `results`, and `spectralTemplates`. 
 
 - `configFiles`: contains your `MasterConfig.yaml` file, as well as some files describing the LSF of your chosen instrument and SSP template set. Also included are some files describing the emission lines to fit, and the line strengh indices. 
 


### PR DESCRIPTION
The url of the repository is wrong in the documentation, this PR just fixes the names, substituting - by _.